### PR TITLE
Add/authority to users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  enum authority: { standard: "standard", admin: "admin" }, _suffix: true
+
   validates :username, presence: true
   validates :username, uniqueness: { case_sensitive: false } # case sensitive by default
   validates :username, length: { in: 3..15 }

--- a/app/views/api/v1/messages/index.json.jbuilder
+++ b/app/views/api/v1/messages/index.json.jbuilder
@@ -2,6 +2,6 @@ json.array! @messages do |message|
   json.extract! message, :id, :created_at, :content
 
   json.user do
-    json.extract! message.user, :username
+    json.extract! message.user, :username, :authority
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,9 @@ module ChatRailsRedux
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    # force pgsql to use structure.sql rather than schema so that we can use sql enums
+    config.active_record.schema_format = :sql
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/db/migrate/20210419102057_add_authority_to_users.rb
+++ b/db/migrate/20210419102057_add_authority_to_users.rb
@@ -1,0 +1,16 @@
+class AddAuthorityToUsers < ActiveRecord::Migration[6.0]
+ def up
+    execute <<-SQL
+      CREATE TYPE user_authority AS ENUM ('standard', 'admin');
+    SQL
+    add_column :users, :authority, :user_authority, default: 'standard'
+    add_index :users, :authority
+  end
+
+  def down
+    remove_column :users, :authority
+    execute <<-SQL
+      DROP TYPE user_authority;
+    SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,0 +1,282 @@
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: user_authority; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.user_authority AS ENUM (
+    'standard',
+    'admin'
+);
+
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ar_internal_metadata (
+    key character varying NOT NULL,
+    value character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: channels; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.channels (
+    id bigint NOT NULL,
+    name character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: channels_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.channels_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: channels_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.channels_id_seq OWNED BY public.channels.id;
+
+
+--
+-- Name: messages; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.messages (
+    id bigint NOT NULL,
+    user_id bigint NOT NULL,
+    channel_id bigint NOT NULL,
+    content text,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: messages_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.messages_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: messages_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.messages_id_seq OWNED BY public.messages.id;
+
+
+--
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.schema_migrations (
+    version character varying NOT NULL
+);
+
+
+--
+-- Name: users; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.users (
+    id bigint NOT NULL,
+    email character varying DEFAULT ''::character varying NOT NULL,
+    encrypted_password character varying DEFAULT ''::character varying NOT NULL,
+    reset_password_token character varying,
+    reset_password_sent_at timestamp without time zone,
+    remember_created_at timestamp without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    username character varying,
+    authentication_token character varying(30),
+    authority public.user_authority DEFAULT 'standard'::public.user_authority
+);
+
+
+--
+-- Name: users_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.users_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.users_id_seq OWNED BY public.users.id;
+
+
+--
+-- Name: channels id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.channels ALTER COLUMN id SET DEFAULT nextval('public.channels_id_seq'::regclass);
+
+
+--
+-- Name: messages id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.messages ALTER COLUMN id SET DEFAULT nextval('public.messages_id_seq'::regclass);
+
+
+--
+-- Name: users id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.users ALTER COLUMN id SET DEFAULT nextval('public.users_id_seq'::regclass);
+
+
+--
+-- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ar_internal_metadata
+    ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
+
+
+--
+-- Name: channels channels_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.channels
+    ADD CONSTRAINT channels_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: messages messages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.messages
+    ADD CONSTRAINT messages_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.schema_migrations
+    ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.users
+    ADD CONSTRAINT users_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: index_messages_on_channel_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_messages_on_channel_id ON public.messages USING btree (channel_id);
+
+
+--
+-- Name: index_messages_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_messages_on_user_id ON public.messages USING btree (user_id);
+
+
+--
+-- Name: index_users_on_authentication_token; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_users_on_authentication_token ON public.users USING btree (authentication_token);
+
+
+--
+-- Name: index_users_on_authority; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_users_on_authority ON public.users USING btree (authority);
+
+
+--
+-- Name: index_users_on_email; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_users_on_email ON public.users USING btree (email);
+
+
+--
+-- Name: index_users_on_reset_password_token; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_users_on_reset_password_token ON public.users USING btree (reset_password_token);
+
+
+--
+-- Name: messages fk_rails_273a25a7a6; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.messages
+    ADD CONSTRAINT fk_rails_273a25a7a6 FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
+-- Name: messages fk_rails_5baf0f07af; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.messages
+    ADD CONSTRAINT fk_rails_5baf0f07af FOREIGN KEY (channel_id) REFERENCES public.channels(id);
+
+
+--
+-- PostgreSQL database dump complete
+--
+
+SET search_path TO "$user", public;
+
+INSERT INTO "schema_migrations" (version) VALUES
+('20210409095434'),
+('20210409104521'),
+('20210409104651'),
+('20210409135045'),
+('20210415094626'),
+('20210419102057');
+
+

--- a/spec/api/get_messages_spec.rb
+++ b/spec/api/get_messages_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "API#GET_MESSAGES", type: :request do
       expect(JSON.parse(response.body).size).to eq(20)
     end
 
-    it 'returns messages with the keys [id, user, content, created_at], but only shows users\' username' do
+    it 'returns messages with the keys [id, user, content, created_at], but only shows users\' username and authority' do
       call_get
 
       message = JSON.parse(response.body).first
@@ -53,6 +53,7 @@ RSpec.describe "API#GET_MESSAGES", type: :request do
       expect(message.key?("created_at")).to be(true)
 
       expect(message["user"].key?("username")).to be(true)
+      expect(message["user"].key?("authority")).to be(true)
       expect(message["user"].key?("id")).to be(false)
       expect(message["user"].key?("created_at")).to be(false)
       expect(message["user"].key?("updated_at")).to be(false)

--- a/spec/api/get_messages_spec.rb
+++ b/spec/api/get_messages_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "API#GET_MESSAGES", type: :request do
       expect(JSON.parse(response.body).size).to eq(20)
     end
 
-    it 'returns messages with the keys [id, user, content, created_at], but only shows users\' username and authority' do
+    it 'returns messages with the keys [id, user, content, created_at], but only shows users username and authority' do
       call_get
 
       message = JSON.parse(response.body).first

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -75,6 +75,15 @@ RSpec.describe User, type: :model do
 
       expect(user.authentication_token).not_to be(nil)
     end
+
+    it "should gain standard authority on create" do
+      expect(user.authority).to be(nil)
+      expect(user.valid?).to be(true)
+
+      user.save!
+
+      expect(user.authority).to eq("standard")
+    end
   end
 
   context "associations:" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -76,12 +76,8 @@ RSpec.describe User, type: :model do
       expect(user.authentication_token).not_to be(nil)
     end
 
-    it "should gain standard authority on create" do
-      expect(user.authority).to be(nil)
-      expect(user.valid?).to be(true)
-
+    it "should gain standard authority by default" do
       user.save!
-
       expect(user.authority).to eq("standard")
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -84,6 +84,16 @@ RSpec.describe User, type: :model do
 
       expect(user.authority).to eq("standard")
     end
+
+    it "should have .authority? method" do
+      user.save!
+      expect(user).to respond_to(:authority?)
+    end
+
+    it "should have .standard_authority? and .admin_authority? method" do
+      user.save!
+      expect(user).to respond_to(:standard_authority?, :admin_authority?)
+    end
   end
 
   context "associations:" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -94,6 +94,10 @@ RSpec.describe User, type: :model do
       user.save!
       expect(user).to respond_to(:standard_authority?, :admin_authority?)
     end
+    it "should have .standard_authority! and .admin_authority! method" do
+      user.save!
+      expect(user).to respond_to(:standard_authority!, :admin_authority!)
+    end
   end
 
   context "associations:" do


### PR DESCRIPTION
Add authority to users with spec. Uses a new SQL enum type. 
Authority levels added: standard, admin

<level>_authority? and <level>_authority! are now ready to be used.

Database now uses structure.sql instead of schema to allow pg to use sql enums. Schema can now be safely deleted, but will be kept temporarily.