### PR TITLE
Add/owner to channels

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -8,4 +8,6 @@ class Channel < ApplicationRecord
 
   has_many :messages, dependent: :destroy
   has_many :users, through: :messages
+
+  belongs_to :owner, class_name: "User", foreign_key: :user_id, optional: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,8 @@ class User < ApplicationRecord
             format: { with: /\A(\w|-)+\z/, message: "%{value} must only contain letters, numbers or underscores" }
 
   has_many :messages
-  has_many :channels, through: :messages
+  has_many :participated_channels, through: :messages, source: :channel
+  has_many :owned_channels, class_name: "Channel"
 
   before_destroy :change_messages_owner
 

--- a/app/views/api/v1/channels/index.json.jbuilder
+++ b/app/views/api/v1/channels/index.json.jbuilder
@@ -1,6 +1,9 @@
 json.array! @channels do |channel|
   json.extract! channel, :name
+
   if channel.owner
-    json.owner_username { json.extract! channel.owner, :username }
+    json.owner_username do
+      json.extract! channel.owner, :username
+    end
   end
 end

--- a/app/views/api/v1/channels/index.json.jbuilder
+++ b/app/views/api/v1/channels/index.json.jbuilder
@@ -1,3 +1,6 @@
 json.array! @channels do |channel|
   json.extract! channel, :name
+  if channel.owner
+    json.owner_username { json.extract! channel.owner, :username }
+  end
 end

--- a/db/migrate/20210419114626_add_owner_to_channels.rb
+++ b/db/migrate/20210419114626_add_owner_to_channels.rb
@@ -1,0 +1,5 @@
+class AddOwnerToChannels < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :channels, :user, null: true, foreign_key: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -43,7 +43,8 @@ CREATE TABLE public.channels (
     id bigint NOT NULL,
     name character varying,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    user_id bigint
 );
 
 
@@ -208,6 +209,13 @@ ALTER TABLE ONLY public.users
 
 
 --
+-- Name: index_channels_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_channels_on_user_id ON public.channels USING btree (user_id);
+
+
+--
 -- Name: index_messages_on_channel_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -266,6 +274,14 @@ ALTER TABLE ONLY public.messages
 
 
 --
+-- Name: channels fk_rails_e3493648f1; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.channels
+    ADD CONSTRAINT fk_rails_e3493648f1 FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
 -- PostgreSQL database dump complete
 --
 
@@ -277,6 +293,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210409104651'),
 ('20210409135045'),
 ('20210415094626'),
-('20210419102057');
+('20210419102057'),
+('20210419114626');
 
 

--- a/spec/api/get_channel_spec.rb
+++ b/spec/api/get_channel_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "API#GET_CHANNELS", type: :request do
 
       expect(channel.key?("name")).to be(true)
       expect(channel.key?("id")).to be(false)
-      
+
       expect(channel.key?("owner_username")).to be(true)
     end
 

--- a/spec/api/get_channel_spec.rb
+++ b/spec/api/get_channel_spec.rb
@@ -39,7 +39,19 @@ RSpec.describe "API#GET_CHANNELS", type: :request do
       expect(JSON.parse(response.body).size).to eq(Channel.count)
     end
 
-    it 'returns only channel name, no id and channel owners username' do
+    it 'returns only channel name, no id if there is no owner' do
+      call_get
+
+      channel = JSON.parse(response.body).first
+
+      expect(channel.key?("name")).to be(true)
+      expect(channel.key?("id")).to be(false)
+    end
+
+    it 'returns only channel name, no id and also channel owner_username if there is an owner' do
+      Channel.destroy_all
+      current_user.owned_channels.create(name: "general")
+
       call_get
 
       channel = JSON.parse(response.body).first

--- a/spec/api/get_channel_spec.rb
+++ b/spec/api/get_channel_spec.rb
@@ -39,13 +39,15 @@ RSpec.describe "API#GET_CHANNELS", type: :request do
       expect(JSON.parse(response.body).size).to eq(Channel.count)
     end
 
-    it 'returns only channel name, no id' do
+    it 'returns only channel name, no id and channel owners username' do
       call_get
 
       channel = JSON.parse(response.body).first
 
       expect(channel.key?("name")).to be(true)
       expect(channel.key?("id")).to be(false)
+      
+      expect(channel.key?("owner_username")).to be(true)
     end
 
     it "should return an empty when there are no channels" do

--- a/spec/models/channel_spec.rb
+++ b/spec/models/channel_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Channel, type: :model do
   end
 
   context "validations:" do
-    it "should be valid with valid attributes" do
+    it "should be valid with valid attributes (even without an owner)" do
       expect(channel).to be_valid
     end
 
@@ -86,6 +86,14 @@ RSpec.describe Channel, type: :model do
       user.save!
       channel.messages.create!(user: user, content: "a lovely message")
       expect(channel.users.count).to eq(1)
+    end
+
+    it "belongs to a user, but is renamed as owner" do
+      user.save!
+      new_channel = user.channels.create(valid_attributes)
+
+      expect(new_channel).to respond_to(:owner)
+      expect(new_channel.owner).to eq(user)
     end
 
     it "should delete its messages upon destroying" do

--- a/spec/models/channel_spec.rb
+++ b/spec/models/channel_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Channel, type: :model do
 
     it "belongs to a user, but is renamed as owner" do
       user.save!
-      new_channel = user.channels.create(valid_attributes)
+      new_channel = user.owned_channels.create(valid_attributes)
 
       expect(new_channel).to respond_to(:owner)
       expect(new_channel.owner).to eq(user)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe User, type: :model do
       expect(user).to respond_to(:owned_channels)
       expect(user.owned_channels.count).to eq(0)
 
-      user.channels.create!(name: "general")
+      user.owned_channels.create!(name: "general")
 
       expect(user.owned_channels.count).to eq(1)
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -111,15 +111,25 @@ RSpec.describe User, type: :model do
       expect(Message.count).to eq(1)
     end
 
-    it "should have many channels" do
+    it "should have many #participated_channels through messages" do
       user.save!
-      expect(user).to respond_to(:channels)
-      expect(user.channels.count).to eq(0)
+      expect(user).to respond_to(:participated_channels)
+      expect(user.participated_channels.count).to eq(0)
 
       channel = Channel.create!(name: "general")
       channel.messages.create!(user: user, content: "a lovely message")
 
-      expect(user.channels.count).to eq(1)
+      expect(user.participated_channels.count).to eq(1)
+    end
+
+    it "should have many #owned_channels through creating them" do
+      user.save!
+      expect(user).to respond_to(:owned_channels)
+      expect(user.owned_channels.count).to eq(0)
+
+      user.channels.create!(name: "general")
+
+      expect(user.owned_channels.count).to eq(1)
     end
   end
 end


### PR DESCRIPTION
**Completed with spec.**

- Channel can now have an owner (optional)
- User has many channels, renamed as # owned_channels
- User's channels through messages is now # participated_channels
- Added owner_username to get channel API endpoint