### PR TITLE
Update/API channel requests

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -8,9 +8,9 @@ class Api::V1::BaseController < ActionController::API
 
   private
 
-  def user_not_authorized(exception)
+  def user_not_authorized(err)
     render json: {
-      error: "Unauthorized #{exception.policy.class.to_s.underscore.camelize}.#{exception.query}"
+      error: err
     }, status: :unauthorized
   end
 

--- a/app/controllers/api/v1/channels_controller.rb
+++ b/app/controllers/api/v1/channels_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::ChannelsController < Api::V1::BaseController
   acts_as_token_authentication_handler_for User
-  before_action :set_channel, only: [:update]
-  after_action :verify_authorized, only: [:index, :update]
+  before_action :set_channel, only: [:update, :destroy]
+  after_action :verify_authorized, only: [:index, :update, :destroy]
   after_action :verify_policy_scoped, only: [:index]
 
   def index
@@ -26,6 +26,10 @@ class Api::V1::ChannelsController < Api::V1::BaseController
     render_bad_content if channel_params == {}
 
     @channel.update(channel_params)
+  end
+
+  def destroy
+
   end
 
   private

--- a/app/controllers/api/v1/channels_controller.rb
+++ b/app/controllers/api/v1/channels_controller.rb
@@ -23,6 +23,8 @@ class Api::V1::ChannelsController < Api::V1::BaseController
   def update
     authorize @channel
 
+    render_bad_content if channel_params == {}
+
     @channel.update(channel_params)
   end
 
@@ -34,6 +36,11 @@ class Api::V1::ChannelsController < Api::V1::BaseController
 
   def channel_params
     params.require(:channel).permit(:name)
+  end
+
+  def render_bad_content
+    render json: { error: "You need to supply a valid channel parameter to update, such as name." },
+           status: :bad_request
   end
 
   def render_invalid_channel_error

--- a/app/controllers/api/v1/channels_controller.rb
+++ b/app/controllers/api/v1/channels_controller.rb
@@ -29,7 +29,7 @@ class Api::V1::ChannelsController < Api::V1::BaseController
   end
 
   def destroy
-
+    authorize @channel
   end
 
   private

--- a/app/controllers/api/v1/channels_controller.rb
+++ b/app/controllers/api/v1/channels_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::ChannelsController < Api::V1::BaseController
   acts_as_token_authentication_handler_for User
-  after_action :verify_authorized, only: [:index]
+  before_action :set_channel, only: [:update]
+  after_action :verify_authorized, only: [:index, :update]
   after_action :verify_policy_scoped, only: [:index]
 
   def index
@@ -19,7 +20,17 @@ class Api::V1::ChannelsController < Api::V1::BaseController
     end
   end
 
+  def update
+    authorize @channel
+
+    @channel.update(channel_params)
+  end
+
   private
+
+  def set_channel
+    @channel = Channel.find_by(name: params[:id])
+  end
 
   def channel_params
     params.require(:channel).permit(:name)

--- a/app/controllers/api/v1/channels_controller.rb
+++ b/app/controllers/api/v1/channels_controller.rb
@@ -30,6 +30,8 @@ class Api::V1::ChannelsController < Api::V1::BaseController
 
   def destroy
     authorize @channel
+
+    @channel.destroy
   end
 
   private

--- a/app/policies/channel_policy.rb
+++ b/app/policies/channel_policy.rb
@@ -12,4 +12,16 @@ class ChannelPolicy < ApplicationPolicy
   def index?
     user_logged_in?
   end
+
+  def update?
+    return true if user_logged_in? && user_is_authorized?
+
+    raise Pundit::NotAuthorizedError, 'Request declined. You are not an admin or owner of the channel.'
+  end
+
+  private
+
+  def user_is_authorized?
+    @user.admin_authority? || (@record.owner == @user)
+  end
 end

--- a/app/policies/channel_policy.rb
+++ b/app/policies/channel_policy.rb
@@ -14,12 +14,20 @@ class ChannelPolicy < ApplicationPolicy
   end
 
   def update?
+    user_is_authenticated_and_authorized?
+  end
+
+  def destroy?
+    user_is_authenticated_and_authorized?
+  end
+  
+  private
+
+  def user_is_authenticated_and_authorized?
     return true if user_logged_in? && user_is_authorized?
 
     raise Pundit::NotAuthorizedError, 'Request declined. You are not an admin or owner of the channel.'
   end
-
-  private
 
   def user_is_authorized?
     @user.admin_authority? || (@record.owner == @user)

--- a/app/policies/channel_policy.rb
+++ b/app/policies/channel_policy.rb
@@ -20,7 +20,7 @@ class ChannelPolicy < ApplicationPolicy
   def destroy?
     user_is_authenticated_and_authorized?
   end
-  
+
   private
 
   def user_is_authenticated_and_authorized?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
 
   namespace :api, defaults: { format: :json } do
     namespace :v1 do
-      resources :channels, only: [ :index, :create ] do
+      resources :channels, only: [ :index, :create, :update ] do
         resources :messages, only: [ :index, :create ]
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
 
   namespace :api, defaults: { format: :json } do
     namespace :v1 do
-      resources :channels, only: [ :index, :create, :update ] do
+      resources :channels, only: [ :index, :create, :update, :destroy ] do
         resources :messages, only: [ :index, :create ]
       end
     end

--- a/spec/api/delete_channel_spec.rb
+++ b/spec/api/delete_channel_spec.rb
@@ -56,28 +56,34 @@ RSpec.describe "API#DELETE_CHANNEL", type: :request do
     # standard user deleting their own channel
     it 'should pass and return status code success when you are are owner of the channel' do
       standards_channel.save!
+      count_before = Channel.count
+
       call_delete(standards_channel, headers(standard_user))
 
       expect(response).to have_http_status(:success)
-      expect(Channel.find(standards_channel.id)).to be(nil)
+      expect(Channel.count).to eq(count_before - 1)
     end
 
     # admin user deleting another users' channel
     it 'should pass and return status code success when you are are an admin' do
       standards_channel.save!
+      count_before = Channel.count
+
       call_delete(standards_channel, headers(admin_user))
 
       expect(response).to have_http_status(:success)
-      expect(Channel.find(standards_channel.id)).to be(nil)
+      expect(Channel.count).to eq(count_before - 1)
     end
 
     # admin user deleting their own channel
     it 'should pass and return status code success when you are are an admin and owner' do
       admins_channel.save!
+      count_before = Channel.count
+
       call_delete(admins_channel, headers(admin_user))
 
       expect(response).to have_http_status(:success)
-      expect(Channel.find(admins_channel.id)).to be(nil)
+      expect(Channel.count).to eq(count_before - 1)
     end
   end
 end

--- a/spec/api/delete_channel_spec.rb
+++ b/spec/api/delete_channel_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+require_relative '../support/api_helper'
+
+RSpec.describe "API#DELETE_CHANNEL", type: :request do
+  let!(:standard_user) { FactoryBot.create(:user) }
+  let!(:another_user) { FactoryBot.create(:user) }
+  let!(:admin_user) { FactoryBot.create(:user, admin: true) }
+  let!(:unowned_channel) { FactoryBot.build(:channel) }
+  let!(:standards_channel) { FactoryBot.build(:owned_channel, owner: standard_user) }
+  let!(:admins_channel) { FactoryBot.build(:owned_channel, owner: admin_user) }
+
+  def headers(user = standard_user)
+    {
+      "X-User-Email": user.email,
+      "X-User-Token": user.authentication_token
+    }
+  end
+
+  def call_delete(channel, hdr = headers)
+    delete "/api/v1/channels/#{channel.name}", headers: hdr
+  end
+
+  # not authenticated
+  context 'DELETE request when not authenticated' do
+    it 'returns status code 401 (unauthorized) and error about signing in when given no email' do
+      unowned_channel.save!
+      call_delete(unowned_channel, without_key(headers, :"X-User-Email"))
+
+      expect(response).to have_http_status(401)
+      expect(get_error(response)).to eq("You need to sign in or sign up before continuing.")
+      expect(Channel.find(unowned_channel.id)).not_to be(nil)
+    end
+
+    it 'returns status code 401 (unauthorized) and error about signing in when given no token' do
+      unowned_channel.save!
+      call_delete(unowned_channel, without_key(headers, :"X-User-Token"))
+
+      expect(response).to have_http_status(401)
+      expect(get_error(response)).to eq("You need to sign in or sign up before continuing.")
+      expect(Channel.find(unowned_channel.id)).not_to be(nil)
+    end
+  end
+
+  # when authenticated
+  context 'DELETE request when authenticated' do
+    # standard user trying to delete another users channel
+    it 'should fail and return status code 401 (unauthorised) when you are not owner or admin' do
+      standards_channel.save!
+      call_delete(standards_channel, headers(another_user))
+
+      expect(response).to have_http_status(401) # not authorized
+      expect(get_error(response)).to eq("Request declined. You are not an admin or owner of the channel.")
+      expect(Channel.find(standards_channel.id)).not_to be(nil)
+    end
+
+    # standard user deleting their own channel
+    it 'should pass and return status code success when you are are owner of the channel' do
+      standards_channel.save!
+      call_delete(standards_channel, headers(standard_user))
+
+      expect(response).to have_http_status(:success)
+      expect(Channel.find(standards_channel.id)).to be(nil)
+    end
+
+    # admin user deleting another users' channel
+    it 'should pass and return status code success when you are are an admin' do
+      standards_channel.save!
+      call_delete(standards_channel, headers(admin_user))
+
+      expect(response).to have_http_status(:success)
+      expect(Channel.find(standards_channel.id)).to be(nil)
+    end
+
+    # admin user deleting their own channel
+    it 'should pass and return status code success when you are are an admin and owner' do
+      admins_channel.save!
+      call_delete(admins_channel, headers(admin_user))
+
+      expect(response).to have_http_status(:success)
+      expect(Channel.find(admins_channel.id)).to be(nil)
+    end
+  end
+end

--- a/spec/api/patch_channel_spec.rb
+++ b/spec/api/patch_channel_spec.rb
@@ -1,8 +1,7 @@
 require 'rails_helper'
 require_relative '../support/api_helper'
-require 'pry-byebug'
 
-RSpec.describe "API#PATCH_CHANNELS", type: :request do
+RSpec.describe "API#PATCH_CHANNEL", type: :request do
   let!(:standard_user) { FactoryBot.create(:user) }
   let!(:another_user) { FactoryBot.create(:user) }
   let!(:admin_user) { FactoryBot.create(:user, admin: true) }

--- a/spec/api/patch_channel_spec.rb
+++ b/spec/api/patch_channel_spec.rb
@@ -1,0 +1,119 @@
+require 'rails_helper'
+require_relative '../support/api_helper'
+require 'pry-byebug'
+
+RSpec.describe "API#PATCH_CHANNELS", type: :request do
+  let!(:standard_user) { FactoryBot.create(:user) }
+  let!(:another_user) { FactoryBot.create(:user) }
+  let!(:admin_user) { FactoryBot.create(:user, admin: true) }
+  let!(:unowned_channel) { FactoryBot.create(:channel) }
+  let!(:standards_channel) { FactoryBot.create(:owned_channel, owner: standard_user) }
+  let!(:admins_channel) { FactoryBot.create(:owned_channel, owner: admin_user) }
+
+  let!(:parameters) { { channel: { name: "new_name" } } }
+
+  def headers(user = standard_user)
+    {
+      "X-User-Email": user.email,
+      "X-User-Token": user.authentication_token
+    }
+  end
+
+  def call_patch(channel, hdr = headers, prm = parameters)
+    patch "/api/v1/channels/#{channel.name}", params: prm, headers: hdr
+  end
+
+  def get_channel_name(channel)
+    Channel.find(channel.id).name
+  end
+
+  def get_channel_owner(channel)
+    Channel.find(channel.id).owner
+  end
+
+  # not authenticated
+  context 'PATCH request when not logged in' do
+    it 'returns status code 401 (unauthorized) and error about signing in when given no email' do
+      call_patch(unowned_channel, without_key(headers, :"X-User-Email"))
+
+      expect(response).to have_http_status(401)
+      expect(get_error(response)).to eq("You need to sign in or sign up before continuing.")
+    end
+
+    it 'returns status code 401 (unauthorized) and error about signing in when given no token' do
+      call_patch(unowned_channel, without_key(headers, :"X-User-Token"))
+
+      expect(response).to have_http_status(401)
+      expect(get_error(response)).to eq("You need to sign in or sign up before continuing.")
+    end
+  end
+
+  # when authenticated
+  context 'PATCH request when logged in' do
+    # not owner or admin, on owned channel
+    it 'returns status code 401 (unauthorised) when you are not owner or admin' do
+      call_patch(standards_channel, headers(another_user))
+
+      expect(response).to have_http_status(401) # not authorized
+      expect(get_error(response)).to eq("Request declined. You are not an admin or owner of the channel.")
+      expect(get_channel_name(standards_channel)).not_to eq("new_name")
+    end
+
+    # not owner or admin, on non-owned channel
+    it 'returns status code 401 (unauthorised) when you are not owner or admin' do
+      call_patch(unowned_channel)
+
+      expect(response).to have_http_status(401) # not authorized
+      expect(get_error(response)).to eq("Request declined. You are not an admin or owner of the channel.")
+      expect(get_channel_name(unowned_channel)).not_to eq("new_name")
+    end
+
+    # owner of channel
+    it 'successfully changes the channel name, when a standard user is owner of the channel' do
+      call_patch(standards_channel)
+
+      expect(response).to have_http_status(:success)
+      expect(get_channel_name(standards_channel)).to eq("new_name")
+    end
+
+    # owner and admin of a channel
+    it 'successfully changes the channel name, when an admin, and owner of the channel' do
+      call_patch(admins_channel, headers(admin_user))
+
+      expect(response).to have_http_status(:success)
+      expect(get_channel_name(admins_channel)).to eq("new_name")
+    end
+
+    # admin, channel does not have owner
+    it 'successfully changes the channel name of an unowned, when an admin' do
+      call_patch(unowned_channel, headers(admin_user))
+
+      expect(response).to have_http_status(:success)
+      expect(get_channel_name(unowned_channel)).to eq("new_name")
+    end
+
+    # when admin and channel has a different owner
+    it 'successfully changes the channel name, when an admin, but not owner of the channel' do
+      call_patch(standards_channel, headers(admin_user))
+
+      expect(response).to have_http_status(:success)
+      expect(get_channel_name(standards_channel)).to eq("new_name")
+    end
+
+    it 'should fail by ignoring unpermitted params, such as owner, even for an admin' do
+      call_patch(standards_channel, headers(admin_user), { channel: { owner: admin_user } })
+
+      expect(response).to have_http_status(400) # bad content (no useful/valid params to update channel with)
+      expect(get_error(response)).to eq("You need to supply a valid channel parameter to update, such as name.")
+      expect(get_channel_owner(standards_channel)).to eq(standard_user)
+    end
+
+    it 'should fail by ignoring unpermitted params, such as owner, even for an the owner' do
+      call_patch(standards_channel, headers(standard_user), { channel: { owner: admin_user } })
+
+      expect(response).to have_http_status(400) # bad content (no useful/valid params to update channel with)
+      expect(get_error(response)).to eq("You need to supply a valid channel parameter to update, such as name.")
+      expect(get_channel_owner(standards_channel)).to eq(standard_user)
+    end
+  end
+end

--- a/spec/factories/channel.rb
+++ b/spec/factories/channel.rb
@@ -3,5 +3,9 @@ require 'faker'
 FactoryBot.define do
   factory :channel do
     name { Faker::Lorem.characters(number: 8) }
+
+    factory :owned_channel do
+      owner { association :user }
+    end
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -2,8 +2,16 @@ require 'faker'
 
 FactoryBot.define do
   factory :user do
+    transient do
+      admin { false }
+    end
+
     username { Faker::Lorem.characters(number: 8) }
     email { Faker::Internet.unique.email }
     password { Faker::Lorem.characters(number: 10) }
+
+    after(:create) do |user, evaluator|
+      user&.admin_authority! if evaluator.admin
+    end
   end
 end


### PR DESCRIPTION
Added delete and edit channel (only name) API functionality. Only admins or owners of the channel are authorized to do these requests. Complete with spec.

Green on Rubocop and passes all tests.