### PR TITLE
Fix/api json

### DIFF
--- a/app/views/api/v1/channels/index.json.jbuilder
+++ b/app/views/api/v1/channels/index.json.jbuilder
@@ -1,9 +1,5 @@
 json.array! @channels do |channel|
-  json.extract! channel, :name
+  json.channel_name channel.name
 
-  if channel.owner
-    json.owner_username do
-      json.extract! channel.owner, :username
-    end
-  end
+  json.owner_username channel.owner&.username
 end

--- a/app/views/api/v1/messages/index.json.jbuilder
+++ b/app/views/api/v1/messages/index.json.jbuilder
@@ -1,7 +1,7 @@
 json.array! @messages do |message|
   json.extract! message, :id, :created_at, :content
 
-  json.user do
-    json.extract! message.user, :username, :authority
+  json.author do
+    json.extract! message.user, :username
   end
 end

--- a/spec/api/get_channel_spec.rb
+++ b/spec/api/get_channel_spec.rb
@@ -42,10 +42,12 @@ RSpec.describe "API#GET_CHANNELS", type: :request do
     it 'returns only channel name, no id if there is no owner' do
       call_get
 
-      channel = JSON.parse(response.body).first
+      channel_json = JSON.parse(response.body).first
 
-      expect(channel.key?("name")).to be(true)
-      expect(channel.key?("id")).to be(false)
+      expect(channel_json.key?("channel_name")).to be(true)
+      expect(channel_json.key?("id")).to be(false)
+      expect(channel_json.key?("owner_username")).to be(true)
+      expect(channel_json["owner_username"]).to eq(nil)
     end
 
     it 'returns only channel name, no id and also channel owner_username if there is an owner' do
@@ -54,12 +56,12 @@ RSpec.describe "API#GET_CHANNELS", type: :request do
 
       call_get
 
-      channel = JSON.parse(response.body).first
+      channel_json = JSON.parse(response.body).first
 
-      expect(channel.key?("name")).to be(true)
-      expect(channel.key?("id")).to be(false)
+      expect(channel_json.key?("channel_name")).to be(true)
+      expect(channel_json.key?("id")).to be(false)
 
-      expect(channel.key?("owner_username")).to be(true)
+      expect(channel_json["owner_username"]).to eq(current_user.username)
     end
 
     it "should return an empty when there are no channels" do

--- a/spec/api/get_messages_spec.rb
+++ b/spec/api/get_messages_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "API#GET_MESSAGES", type: :request do
       expect(JSON.parse(response.body).size).to eq(20)
     end
 
-    it 'returns messages with the keys [id, user, content, created_at], but only shows users username and authority' do
+    it 'returns messages with the keys [id, user, content, created_at], but only shows users username' do
       call_get
 
       message = JSON.parse(response.body).first
@@ -53,7 +53,7 @@ RSpec.describe "API#GET_MESSAGES", type: :request do
       expect(message.key?("created_at")).to be(true)
 
       expect(message["user"].key?("username")).to be(true)
-      expect(message["user"].key?("authority")).to be(true)
+      expect(message["user"].key?("authority")).to be(false)
       expect(message["user"].key?("id")).to be(false)
       expect(message["user"].key?("created_at")).to be(false)
       expect(message["user"].key?("updated_at")).to be(false)

--- a/spec/api/get_messages_spec.rb
+++ b/spec/api/get_messages_spec.rb
@@ -48,15 +48,15 @@ RSpec.describe "API#GET_MESSAGES", type: :request do
       message = JSON.parse(response.body).first
 
       expect(message.key?("id")).to be(true)
-      expect(message.key?("user")).to be(true)
       expect(message.key?("content")).to be(true)
       expect(message.key?("created_at")).to be(true)
+      expect(message.key?("author")).to be(true)
 
-      expect(message["user"].key?("username")).to be(true)
-      expect(message["user"].key?("authority")).to be(false)
-      expect(message["user"].key?("id")).to be(false)
-      expect(message["user"].key?("created_at")).to be(false)
-      expect(message["user"].key?("updated_at")).to be(false)
+      expect(message["author"].key?("username")).to be(true)
+      expect(message["author"].key?("authority")).to be(false)
+      expect(message["author"].key?("id")).to be(false)
+      expect(message["author"].key?("created_at")).to be(false)
+      expect(message["author"].key?("updated_at")).to be(false)
     end
 
     it "should return an empty array on a new channel" do


### PR DESCRIPTION
Changed two endpoints and the json they give:

Get channels
- 'name' is now 'channel_name'
- 'owner_username' now gives the string value directly instead of nested in another hash

Get message
- 'user' is now 'author'
- hash no longer says user's authority
 (kept user/author as a hash for near-future model additions)

Built tests first then changes.